### PR TITLE
Allow newer versions of composer installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
   ],
   "type": "wordpress-plugin",
   "require": {
-    "composer/installers": "v1.0.6"
+    "composer/installers": "v1.0.*"
   }
 }


### PR DESCRIPTION
composer/installers has moved to version 1.0.22 at the time of writing this and the plugin should be made to be installable more flexibly otherwise it fails to install with composer if newer is needed elsewhere.