### PR TITLE
Allow newer versions of composer/installers: >= 1.4.0 < 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
   ],
   "type": "wordpress-plugin",
   "require": {
-    "composer/installers": "v1.4.*"
+    "composer/installers": "~1.4"
   }
 }


### PR DESCRIPTION
There's no reason to version lock it within minor releases.